### PR TITLE
feat(keyboard) Optimize keycodes buffers. Use std::array insteadof st…

### DIFF
--- a/src/components/Actions.h
+++ b/src/components/Actions.h
@@ -38,8 +38,7 @@ public:
         : Action<switches_count>(keyboard_state, KCT_INTERNAL) {}
 
     void run() override {
-        for (auto &keycode : keyboard_state_->keycodes[keycode_type]) {
-            printf("Internal keycode!");
+        for (auto &keycode : keyboard_state_->get_keycodes(keycode_type)) {
             if (keycode == INTERNAL_KEY_REBOOT) {
                 // huu robimy reboot!
                 reset_usb_boot(0, 0);
@@ -59,7 +58,7 @@ public:
         : Action<switches_count>(keyboard_state, KCT_MACRO) {}
 
     void run() override {
-        for (auto &keycode : keyboard_state_->keycodes[keycode_type]) {
+        for (auto &keycode : keyboard_state_->get_keycodes(keycode_type)) {
             // TODO make macro!
         }
     }

--- a/src/components/CircularBuffer.h
+++ b/src/components/CircularBuffer.h
@@ -31,7 +31,6 @@ public:
         if (size_ == buffer_.size()) {
             return false;
         } else {
-//            memcpy(&buffer_[write_index_], &el, sizeof(el));
             buffer_[write_index_] = el;
             write_index_ = (write_index_ + 1) % buffer_.size();
             ++size_;
@@ -41,7 +40,6 @@ public:
 
     bool remove_element(item_t &el) {
         if (size_ > 0) {
-//            memcpy(&el, &buffer_[read_index_], sizeof(el));
             el = buffer_[read_index_];
             read_index_ = (read_index_ + 1) % buffer_.size();
             --size_;

--- a/src/components/HIDReporter.h
+++ b/src/components/HIDReporter.h
@@ -46,7 +46,7 @@ protected:
 
 public:
     explicit HIDReporter(KeyboardState<switches_count> *keyboard_state, KeycodeType keycode_type)
-        : keyboard_state_(keyboard_state),  keycode_type(keycode_type) {}
+        : keyboard_state_(keyboard_state), keycode_type(keycode_type) {}
 
     void init() { critical_section_init(&send_report_lock_); }
 
@@ -54,9 +54,7 @@ public:
 
     bool is_report_to_send() { return !report_buffer_.empty(); }
 
-    virtual bool is_report_to_generate() {
-        return keyboard_state_->keycodes[keycode_type] != keyboard_state_->prev_keycodes[keycode_type];
-    }
+    virtual bool is_report_to_generate() { return keyboard_state_->are_keycodes_changed(keycode_type); }
 
     HIDReport *blocking_dequeue_report() {
         HIDReport *report = nullptr;
@@ -99,7 +97,7 @@ public:
     HIDKeyReport *generate_report() {
         uint8_t modifier = 0;
         vector<uint8_t> keycodes{};
-        for (auto &keycode : keyboard_state_->keycodes[keycode_type]) {
+        for (auto &keycode : keyboard_state_->get_keycodes(keycode_type)) {
             if (keycode >= HID_KEY_CONTROL_LEFT) {
                 modifier = modifier | MODIFIER_KEYCODE_TO_BIT[static_cast<uint8_t>(keycode)];
             } else {
@@ -135,9 +133,10 @@ public:
         : HIDReporter<switches_count>(keyboard_state, KCT_CC_KEY) {}
 
     HIDCCReport *generate_report() {
-        if (keyboard_state_->keycodes[keycode_type].empty()) {
+        auto keycodes = keyboard_state_->get_keycodes(keycode_type);
+        if (keycodes.empty()) {
             return new HIDCCReport(0);
         }
-        return new HIDCCReport(keyboard_state_->keycodes[keycode_type].front());
+        return new HIDCCReport(keycodes.front());
     }
 };

--- a/src/components/KeyboardConfig.h
+++ b/src/components/KeyboardConfig.h
@@ -45,9 +45,8 @@ map<uint8_t, uint8_t> MODIFIER_KEYCODE_TO_BIT = {
  * Internal keycodes
  */
 
-#define INTERNAL_KEY_REBOOT         1
+#define INTERNAL_KEY_REBOOT 1
 // some backlights action? other configuration...
-
 
 
 /**
@@ -84,6 +83,7 @@ enum RuleConfigId {
     RID_MS_KEY,
     RID_TD,
 };
+
 
 class RuleConfig {
 public:

--- a/src/components/KeyboardMapper.h
+++ b/src/components/KeyboardMapper.h
@@ -42,22 +42,22 @@ public:
         if (keycode.code > 0) {
             if (keycode.type == KCT_KEY && keycode.code > numeric_limits<uint8_t>::max()) {
                 // base keycode
-                keyboard_state_->emplace_keycode(keycode.type, static_cast<uint8_t>(keycode.code));
+                keyboard_state_->emplace_keycode(Keycode{static_cast<uint8_t>(keycode.code), keycode.type});
                 // modifiers
                 auto modifier_bits = static_cast<uint8_t>(keycode.code >> 8);
                 uint8_t modifier_mask = 1;
                 for (auto &kc : MODIFIER_BIT_TO_KEYCODE) {
                     if (modifier_bits & modifier_mask) {
-                        keyboard_state_->emplace_keycode(keycode.type, kc);
+                        keyboard_state_->emplace_keycode(Keycode{kc, keycode.type});
                     }
                     modifier_mask <<= 1;
                 }
             } else {
-                keyboard_state_->emplace_keycode(keycode.type, keycode.code);
+                keyboard_state_->emplace_keycode(keycode);
             }
             //
-            //            cout << "Emplace keycode: " << to_string(keycode.type) << "|" <<
-            //            to_string(keycode.code) << endl;
+//                        cout << "Emplace keycode: " << to_string(keycode.type) << "|" <<
+//                        to_string(keycode.code) << endl;
             //
 
             return true;

--- a/src/components/KeyboardState.h
+++ b/src/components/KeyboardState.h
@@ -31,7 +31,8 @@ public:
         uint16_t switch_pressed_duration_ms,
         uint16_t switch_tap_interval_ms,
         uint16_t switch_hold_duration_ms)
-        : keyboard_refresh_interval_ms(refresh_interval_ms), usb_refresh_interval_ms(usb_refresh_interval_ms),
+        : keyboard_refresh_interval_ms(refresh_interval_ms),
+          usb_refresh_interval_ms(usb_refresh_interval_ms),
           switch_pressed_duration_ms(switch_pressed_duration_ms),
           switch_tap_interval_ms(switch_tap_interval_ms), switch_hold_duration_ms(switch_hold_duration_ms) {
         switch_pressed_duration_cycles = switch_pressed_duration_ms / refresh_interval_ms;
@@ -84,29 +85,26 @@ public:
     bitset<switches_count> mapped_switches{};    // that switches are mapped in this cycle
 
     // current and prev cycle keycodes
-    array<vector<uint16_t>, KCT_COUNT> keycodes;
-    array<vector<uint16_t>, KCT_COUNT> prev_keycodes;
+    array<Keycode, 200> keycodes{};
+    array<Keycode, 200> prev_keycodes{};
+    size_t keycodes_index = 0;
+    size_t prev_keycodes_index = 0;
+    bool keycodes_ready = false;
 
     KeyboardState() {
         fill(begin(switches_state), end(switches_state), SwitchState{});
-        for (int keycode_type = KCT_KEY; keycode_type != KCT_COUNT; keycode_type++) {
-            keycodes[keycode_type] = vector<uint16_t>{};
-            prev_keycodes[keycode_type] = vector<uint16_t>{};
-        }
+        fill(begin(keycodes), end(keycodes), Keycode{0, KCT_KEY});
+        fill(begin(prev_keycodes), end(prev_keycodes), Keycode{0, KCT_KEY});
     }
 
     // reset state
     void reset() {
         switches_read_state.reset();
         mapped_switches.reset();
-        // move current keycodes to prev keycodes, reset current keycodes
-        for (int keycode_type = KCT_KEY; keycode_type != KCT_COUNT; keycode_type++) {
-            prev_keycodes[keycode_type].clear();
-            for (auto &keycode : keycodes[keycode_type]) {
-                prev_keycodes[keycode_type].emplace_back(keycode);
-            }
-            keycodes[keycode_type].clear();
-        }
+        prev_keycodes = keycodes;
+        prev_keycodes_index = keycodes_index;
+        fill(begin(keycodes), end(keycodes), Keycode{0, KCT_KEY});
+        keycodes_index = 0;
     }
 
     // layers
@@ -134,17 +132,56 @@ public:
         return switches_state[switch_no].tap_dance_count > 0;
     }
 
-    bool is_tap_dance_end(uint8_t switch_no) {
-        return switches_state[switch_no].tap_dance_end;
-    }
+    bool is_tap_dance_end(uint8_t switch_no) { return switches_state[switch_no].tap_dance_end; }
 
-    uint8_t get_tap_dance_count(uint8_t switch_no) {
-        return switches_state[switch_no].tap_dance_count;
-    }
+    uint8_t get_tap_dance_count(uint8_t switch_no) { return switches_state[switch_no].tap_dance_count; }
 
     // keycodes
 
-    void emplace_keycode(KeycodeType const &keycode_type, uint16_t const &keycode) {
-        keycodes[keycode_type].emplace_back(keycode);
+    bool emplace_keycode(Keycode const &keycode) {
+        if (keycodes_index == keycodes.size()) {
+            return false;
+        }
+        keycodes[keycodes_index] = keycode;
+        keycodes_index++;
+        return true;
+    }
+
+    bool are_keycodes_changed(KeycodeType const &keycode_type) {
+        if (keycodes_index == 0 && prev_keycodes_index == 0) {
+            return false;
+        }
+        size_t index = 0;
+        size_t prev_index = 0;
+        while ((index <= keycodes_index) && (prev_index <= prev_keycodes_index)) {
+            if (keycodes_index > 0 && keycodes[index].type != keycode_type) {
+                ++index;
+                continue;
+            }
+            if (prev_keycodes_index > 0 && prev_keycodes[prev_index].type != keycode_type) {
+                ++prev_index;
+                continue;
+            }
+            if (keycodes_index > 0 && prev_keycodes_index > 0) {
+                if (keycodes[index].code != prev_keycodes[prev_index].code) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
+            ++index;
+            ++prev_index;
+        }
+        return false;
+    }
+
+    auto get_keycodes(KeycodeType const &keycode_type) {
+        std::vector<uint16_t> out_keycodes;
+        for (auto index = 0; index < keycodes_index; ++index) {
+            if (keycodes[index].type == keycode_type) {
+                out_keycodes.emplace_back(keycodes[index].code);
+            }
+        }
+        return out_keycodes;
     }
 };

--- a/tests/test_circular_buffer.cpp
+++ b/tests/test_circular_buffer.cpp
@@ -3,6 +3,20 @@
 
 #include "components/CircularBuffer.h"
 
+void test_circular_buffer__empty() {
+    CircularBuffer<uint8_t, 5> buffer;
+   cout << "CircularBuffer, test empty" << endl;
+   assert(buffer.empty());
+
+   uint8_t el = 11;
+   buffer.add_element(el);
+   assert(!buffer.empty());
+
+   buffer.remove_element(el);
+   assert(buffer.empty());
+   cout << "ok" << endl;
+}
+
 
 void test_circular_buffer() {
     CircularBuffer<uint8_t, 5> buffer;

--- a/tests/test_keyboard_state.cpp
+++ b/tests/test_keyboard_state.cpp
@@ -1,0 +1,163 @@
+
+#include "pico/stdlib.h"
+#include <iostream>
+
+#include "components/KeyboardConfig.h"
+#include "components/KeyboardState.h"
+#include "components/SwitchStateUpdater.h"
+
+
+// void print_switch_state(SwitchState &s, int8_t cycle = -1) {
+//     // clang-format off
+//     if (cycle >= 0) {
+//         cout << "C" << to_string(cycle) << " | ";
+//     }
+//     cout
+//         << to_string(s.pressed)
+//         << " | " << to_string(s.released)
+//         << " | " << to_string(s.tap_dance_count)
+//         << " | " << to_string(s.tap_dance_end)
+//         << endl;
+//     // clang-format on
+// }
+
+
+void test_keyboard_state__emplace_keycode() {
+    auto keyboard_state = new KeyboardState<3>{};
+
+    cout << "KeyboardState emplace_keycode" << endl;
+    cout << ".  emplace 4 keycodes and check state" << endl;
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{20, KCT_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{30, KCT_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_CC_KEY}));
+
+    assert(keyboard_state->prev_keycodes_index == 0);
+    assert(keyboard_state->keycodes_index == 4);
+    assert(keyboard_state->keycodes[0].code == 10);
+    assert(keyboard_state->keycodes[0].type == KCT_KEY);
+    assert(keyboard_state->keycodes[1].code == 20);
+    assert(keyboard_state->keycodes[1].type == KCT_KEY);
+    assert(keyboard_state->keycodes[2].code == 30);
+    assert(keyboard_state->keycodes[2].type == KCT_KEY);
+    assert(keyboard_state->keycodes[3].code == 10);
+    assert(keyboard_state->keycodes[3].type == KCT_CC_KEY);
+
+    cout << "ok" << endl;
+}
+
+
+void test_keyboard_state__keycode_reset() {
+    auto keyboard_state = new KeyboardState<3>{};
+    cout << "KeyboardState emplace_keycode and reset state" << endl;
+    cout << ". emplace 2 keycodes and check state" << endl;
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{20, KCT_KEY}));
+
+    assert(keyboard_state->prev_keycodes_index == 0);
+    assert(keyboard_state->keycodes_index == 2);
+    assert(keyboard_state->keycodes[0].code == 10);
+    assert(keyboard_state->keycodes[0].type == KCT_KEY);
+    assert(keyboard_state->keycodes[1].code == 20);
+    assert(keyboard_state->keycodes[1].type == KCT_KEY);
+
+    cout << ". reset and check state" << endl;
+    keyboard_state->reset();
+    assert(keyboard_state->keycodes_index == 0);
+    assert(keyboard_state->prev_keycodes_index == 2);
+    assert(keyboard_state->prev_keycodes[0].code == 10);
+    assert(keyboard_state->prev_keycodes[0].type == KCT_KEY);
+    assert(keyboard_state->prev_keycodes[1].code == 20);
+    assert(keyboard_state->prev_keycodes[1].type == KCT_KEY);
+
+    cout << "ok" << endl;
+}
+
+
+void test_keyboard_state__keycodes_changed__empty() {
+    auto keyboard_state = new KeyboardState<3>{};
+    cout << "KeyboardState keycodes_changed empty state" << endl;
+    assert(keyboard_state->keycodes_index == 0);
+    assert(keyboard_state->prev_keycodes_index == 0);
+    assert(!keyboard_state->are_keycodes_changed(KCT_KEY));
+    assert(!keyboard_state->are_keycodes_changed(KCT_CC_KEY));
+    cout << "ok" << endl;
+}
+
+
+void test_keyboard_state__keycodes_changed__prev_keycodes_empty() {
+    auto keyboard_state = new KeyboardState<3>{};
+    cout << "KeyboardState keycodes_changed prev_keys empty, current keys not mixed" << endl;
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{20, KCT_KEY}));
+    assert(keyboard_state->keycodes_index == 2);
+    assert(keyboard_state->prev_keycodes_index == 0);
+    assert(keyboard_state->are_keycodes_changed(KCT_KEY));
+    assert(!keyboard_state->are_keycodes_changed(KCT_CC_KEY));
+    cout << "ok" << endl;
+}
+
+
+void test_keyboard_state__keycodes_changed__prev_keycodes_empty_mixed_type() {
+    auto keyboard_state = new KeyboardState<3>{};
+    cout << "KeyboardState keycodes_changed prev_keys empty, current keys mixed" << endl;
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_CC_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{20, KCT_KEY}));
+    assert(keyboard_state->keycodes_index == 3);
+    assert(keyboard_state->prev_keycodes_index == 0);
+    assert(keyboard_state->are_keycodes_changed(KCT_KEY));
+    assert(keyboard_state->are_keycodes_changed(KCT_CC_KEY));
+    cout << "ok" << endl;
+}
+
+
+void test_keyboard_state__keycodes_not_changed__prev_keycodes_not_empty_mixed_type() {
+    auto keyboard_state = new KeyboardState<3>{};
+    cout << "KeyboardState keycodes_changed prev keycodes not empty, keys mixed" << endl;
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_CC_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{20, KCT_KEY}));
+    keyboard_state->reset();
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{20, KCT_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_CC_KEY}));
+    assert(!keyboard_state->are_keycodes_changed(KCT_KEY));
+    assert(!keyboard_state->are_keycodes_changed(KCT_CC_KEY));
+    cout << "ok" << endl;
+}
+
+
+void test_keyboard_state__keycodes_changed__current_keycodes_empty_mixed_type() {
+    auto keyboard_state = new KeyboardState<3>{};
+    cout << "KeyboardState keycodes_changed current keycodes empty, keys mixed" << endl;
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_CC_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{20, KCT_KEY}));
+    keyboard_state->reset();
+    assert(keyboard_state->are_keycodes_changed(KCT_KEY));
+    assert(keyboard_state->are_keycodes_changed(KCT_CC_KEY));
+    cout << "ok" << endl;
+}
+
+
+void test_keyboard_state__get_keycodes() {
+    auto keyboard_state = new KeyboardState<3>{};
+    cout << "KeyboardState keycodes_changed current keycodes empty, keys mixed" << endl;
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{10, KCT_CC_KEY}));
+    assert(keyboard_state->emplace_keycode(Keycode{20, KCT_KEY}));
+
+    auto keycodes = keyboard_state->get_keycodes(KCT_KEY);
+    assert(keycodes.size() == 2);
+    assert(keycodes[0] == 10);
+    assert(keycodes[1] == 20);
+
+    auto cc_keycodes = keyboard_state->get_keycodes(KCT_CC_KEY);
+    assert(cc_keycodes.size() == 1);
+    assert(cc_keycodes[0] == 10);
+
+    auto internal_keycodes = keyboard_state->get_keycodes(KCT_INTERNAL);
+    assert(internal_keycodes.empty());
+    cout << "ok" << endl;
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -5,6 +5,7 @@
 //#include "test_keyboard_matrix.cpp"
 #include "test_circular_buffer.cpp"
 #include "test_switches_state_updater.cpp"
+#include "test_keyboard_state.cpp"
 
 
 using namespace std;
@@ -17,11 +18,23 @@ int main() {
     cout << endl << endl;
 //    test_keyboard_matrix_1();
 //    test_keyboard_matrix_2();
+
+    test_circular_buffer__empty();
     test_circular_buffer();
     test_circular_buffer_circular_rw();
     test_circular_buffer_pointers();
-    test_switches_state_updater_empty();
-    test_switches_state_updater_key_pressed();
-    test_switches_state_updater_tap_dance_count_2();
+
+//    test_switches_state_updater_empty();
+//    test_switches_state_updater_key_pressed();
+//    test_switches_state_updater_tap_dance_count_2();
+
+    test_keyboard_state__emplace_keycode();
+    test_keyboard_state__keycode_reset();
+    test_keyboard_state__keycodes_changed__empty();
+    test_keyboard_state__keycodes_changed__prev_keycodes_empty();
+    test_keyboard_state__keycodes_changed__prev_keycodes_empty_mixed_type();
+    test_keyboard_state__keycodes_not_changed__prev_keycodes_not_empty_mixed_type();
+    test_keyboard_state__keycodes_changed__current_keycodes_empty_mixed_type();
+    test_keyboard_state__get_keycodes();
     cout << "================" << endl;
 }


### PR DESCRIPTION
…d::vector

This change allow to allocate memory only on initialize KeyboardState. Disadvantage of this change is complex work with indexes.